### PR TITLE
Add optional parameter to set the joystick device

### DIFF
--- a/hector_quadrotor_teleop/launch/logitech_gamepad.launch
+++ b/hector_quadrotor_teleop/launch/logitech_gamepad.launch
@@ -1,8 +1,12 @@
 <?xml version="1.0"?>
 
 <launch>
-  <node name="joy" pkg="joy" type="joy_node" output="screen" />
-  
+  <arg name="joy_dev" default="/dev/input/js0" />
+
+  <node name="joy" pkg="joy" type="joy_node" output="screen" >
+    <param name="dev" value="$(arg joy_dev)" />
+  </node>
+
   <!-- Note that axis IDs are those from the joystick message plus one, to be able to invert axes by specifiying either positive or negative axis numbers.-->
   <!-- Axis 2 from joy message thus has to be set as '3' or '-3'(inverted mode) below-->
   <node name="quadrotor_teleop" pkg="hector_quadrotor_teleop" type="quadrotor_teleop">

--- a/hector_quadrotor_teleop/launch/xbox_controller.launch
+++ b/hector_quadrotor_teleop/launch/xbox_controller.launch
@@ -1,7 +1,11 @@
 <?xml version="1.0"?>
 
 <launch>
-  <node name="joy" pkg="joy" type="joy_node" output="screen" />
+  <arg name="joy_dev" default="/dev/input/js0" />
+
+  <node name="joy" pkg="joy" type="joy_node" output="screen" >
+    <param name="dev" value="$(arg joy_dev)" />
+  </node>
 
   <!-- Note that axis IDs are those from the joystick message plus one, to be able to invert axes by specifiying either positive or negative axis numbers.-->
   <!-- Axis 2 from joy message thus has to be set as '3' or '-3'(inverted mode) below-->


### PR DESCRIPTION
This is useful for
a) Multicopter simulations, or
b) If multiple joysticks are attached to the system and a specific one should be used to control the quadcopter.

It did not work for me to just use "rosparam set joy_node/dev /dev/input/jsX" before launching the hector_quadrotor_teleop (ROS Indigo).

I tested it with the XBOX controller which was attached to /dev/input/js1 and the indoor_slam demo.
