### PR TITLE
Add controller timeout to allow faster shutdown of spawner

### DIFF
--- a/hector_quadrotor_controller/launch/controller.launch
+++ b/hector_quadrotor_controller/launch/controller.launch
@@ -3,5 +3,5 @@
 
   <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="
     controller/twist
-  "/>
+     --shutdown-timeout 3"/>
 </launch>


### PR DESCRIPTION
Otherwise, spawner waits ~30 seconds before shutting down.

https://github.com/ros-controls/ros_control/issues/195
