### PR TITLE
Parametrize world and base_link frames for multi-robot operation

### DIFF
--- a/hector_quadrotor_controller/src/motor_controller.cpp
+++ b/hector_quadrotor_controller/src/motor_controller.cpp
@@ -70,6 +70,7 @@ public:
     controller_nh.getParam("force_per_voltage", parameters_.force_per_voltage = 0.559966216);
     controller_nh.getParam("torque_per_voltage", parameters_.torque_per_voltage = 7.98598e-3);
     controller_nh.getParam("lever", parameters_.lever = 0.275);
+    root_nh.param<std::string>("base_link_frame", base_link_frame_, "base_link");
 
     // TODO: calculate these parameters from the quadrotor_propulsion parameters
 //    quadrotor_propulsion:
@@ -171,6 +172,7 @@ private:
 
   geometry_msgs::WrenchStamped wrench_;
   hector_uav_msgs::MotorCommand motor_;
+  std::string base_link_frame_;
 
   struct {
     double force_per_voltage;     // coefficient for linearized volts to force conversion for a single motor [N / V]

--- a/hector_quadrotor_controller/src/twist_controller.cpp
+++ b/hector_quadrotor_controller/src/twist_controller.cpp
@@ -124,6 +124,7 @@ public:
     controller_nh.getParam("limits/torque/xy", limits_.torque.x);
     controller_nh.getParam("limits/torque/xy", limits_.torque.y);
     controller_nh.getParam("limits/torque/z", limits_.torque.z);
+    root_nh.param<std::string>("base_link_frame", base_link_frame_, "base_link");
 
     // get mass and inertia from QuadrotorInterface
     interface->getMassAndInertia(mass_, inertia_);
@@ -317,7 +318,7 @@ public:
 
     // set wrench output
     wrench_.header.stamp = time;
-    wrench_.header.frame_id = "base_link";
+    wrench_.header.frame_id = base_link_frame_;
     wrench_output_->setCommand(wrench_.wrench);
   }
 
@@ -337,6 +338,7 @@ private:
   geometry_msgs::TwistStamped command_;
   geometry_msgs::WrenchStamped wrench_;
   bool command_given_in_stabilized_frame_;
+  std::string base_link_frame_;
 
   struct {
     struct {

--- a/hector_quadrotor_controller_gazebo/include/hector_quadrotor_controller/quadrotor_hardware_gazebo.h
+++ b/hector_quadrotor_controller_gazebo/include/hector_quadrotor_controller/quadrotor_hardware_gazebo.h
@@ -84,6 +84,7 @@ protected:
   Vector3 acceleration_;
   Imu imu_;
   MotorStatus motor_status_;
+  std::string base_link_frame_, world_frame_;
 
   WrenchCommandHandlePtr wrench_output_;
   MotorCommandHandlePtr motor_output_;

--- a/hector_quadrotor_controller_gazebo/src/quadrotor_hardware_gazebo.cpp
+++ b/hector_quadrotor_controller_gazebo/src/quadrotor_hardware_gazebo.cpp
@@ -59,6 +59,9 @@ bool QuadrotorHardwareSim::initSim(
   link_ = model_->GetLink();
   physics_ = model_->GetWorld()->GetPhysicsEngine();
 
+  model_nh.param<std::string>("world_frame", world_frame_, "world");
+  model_nh.param<std::string>("base_link_frame", base_link_frame_, "base_link");
+
   // subscribe state
   std::string state_topic;
   param_nh.getParam("state_topic", state_topic);
@@ -151,7 +154,7 @@ void QuadrotorHardwareSim::readSim(ros::Time time, ros::Duration period)
   gz_angular_velocity_ =  link_->GetWorldAngularVel();
 
   if (!subscriber_state_) {
-    header_.frame_id = "/world";
+    header_.frame_id = world_frame_;
     header_.stamp = time;
     pose_.position.x = gz_pose_.pos.x;
     pose_.position.y = gz_pose_.pos.y;
@@ -201,7 +204,7 @@ void QuadrotorHardwareSim::writeSim(ros::Time time, ros::Duration period)
   if (wrench_output_->connected() && wrench_output_->enabled()) {
     geometry_msgs::WrenchStamped wrench;
     wrench.header.stamp = time;
-    wrench.header.frame_id = "base_link";
+    wrench.header.frame_id = base_link_frame_;
     wrench.wrench = wrench_output_->getCommand();
     publisher_wrench_command_.publish(wrench);
 

--- a/hector_quadrotor_gazebo/launch/spawn_quadrotor.launch
+++ b/hector_quadrotor_gazebo/launch/spawn_quadrotor.launch
@@ -1,69 +1,71 @@
 <?xml version="1.0"?>
 
 <launch>
-   <arg name="name" default="quadrotor"/>
-   <arg name="model" default="$(find hector_quadrotor_description)/urdf/quadrotor.gazebo.xacro"/>
-   <arg name="tf_prefix" default="$(optenv ROS_NAMESPACE)"/>
-   <arg name="x" default="0.0"/>
-   <arg name="y" default="0.0"/>
-   <arg name="z" default="0.3"/>
+  <arg name="name" default="quadrotor"/>
+  <arg name="model" default="$(find hector_quadrotor_description)/urdf/quadrotor.gazebo.xacro"/>
+  <arg name="tf_prefix" default="$(optenv ROS_NAMESPACE)"/>
+  <arg name="controller_definition" default="$(find hector_quadrotor_controller)/launch/controller.launch"/>
 
-   <arg name="use_ground_truth_for_tf" default="true" />
-   <arg name="use_ground_truth_for_control" default="true" />
-   <arg name="use_pose_estimation" if="$(arg use_ground_truth_for_control)" default="false"/>
-   <arg name="use_pose_estimation" unless="$(arg use_ground_truth_for_control)" default="true"/>
+  <arg name="x" default="0.0"/>
+  <arg name="y" default="0.0"/>
+  <arg name="z" default="0.3"/>
 
-   <!-- send the robot XML to param server -->
-   <param name="robot_description" command="$(find xacro)/xacro.py '$(arg model)' base_link_frame:=$(arg tf_prefix)/base_link" />
-   <param name="tf_prefix" type="string" value="$(arg tf_prefix)" />
-   <param name="base_link_frame" type="string" value="$(arg tf_prefix)/base_link"/>
-   <param name="world_frame" type="string" value="world"/>
+  <arg name="use_ground_truth_for_tf" default="true" />
+  <arg name="use_ground_truth_for_control" default="true" />
+  <arg name="use_pose_estimation" if="$(arg use_ground_truth_for_control)" default="false"/>
+  <arg name="use_pose_estimation" unless="$(arg use_ground_truth_for_control)" default="true"/>
 
-   <!-- push robot_description to factory and spawn robot in gazebo -->
-   <node name="spawn_robot" pkg="gazebo_ros" type="spawn_model"
-     args="-param robot_description
+  <!-- send the robot XML to param server -->
+  <param name="robot_description" command="$(find xacro)/xacro.py '$(arg model)' base_link_frame:=$(arg tf_prefix)/base_link" />
+  <param name="tf_prefix" type="string" value="$(arg tf_prefix)" />
+  <param name="base_link_frame" type="string" value="$(arg tf_prefix)/base_link"/>
+  <param name="world_frame" type="string" value="world"/>
+
+  <!-- push robot_description to factory and spawn robot in gazebo -->
+  <node name="spawn_robot" pkg="gazebo_ros" type="spawn_model"
+        args="-param robot_description
            -urdf
            -x $(arg x)
            -y $(arg y)
            -z $(arg z)
            -model $(arg name)"
-     respawn="false" output="screen"/>
-     
-   <!-- start robot state publisher -->
-   <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" output="screen" >
-     <param name="publish_frequency" type="double" value="50.0" />
-   </node>
+        respawn="false" output="screen"/>
 
-   <!-- publish state and tf -->
-   <node name="ground_truth_to_tf" pkg="message_to_tf" type="message_to_tf" output="screen">
-     <param name="odometry_topic" value="ground_truth/state" />
-     <param name="frame_id" value="/world" />
-     <param name="tf_prefix" value="$(arg tf_prefix)" if="$(arg use_ground_truth_for_tf)" />
-     <param name="tf_prefix" value="$(arg tf_prefix)/ground_truth" unless="$(arg use_ground_truth_for_tf)" />
-   </node>
-   <group if="$(arg use_pose_estimation)">
-     <node name="pose_estimation" pkg="hector_quadrotor_pose_estimation" type="hector_quadrotor_pose_estimation" output="screen">
-       <rosparam file="$(find hector_quadrotor_pose_estimation)/params/simulation.yaml" />
-       <param name="nav_frame" value="$(arg tf_prefix)/nav" />
-       <param name="publish_world_nav_transform" value="true" />
-       <param name="tf_prefix" value="$(arg tf_prefix)" unless="$(arg use_ground_truth_for_tf)" />
-       <param name="tf_prefix" value="$(arg tf_prefix)/pose_estimation" if="$(arg use_ground_truth_for_tf)" />
-     </node>
-   </group>
+  <!-- start robot state publisher -->
+  <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" output="screen" >
+    <param name="publish_frequency" type="double" value="50.0" />
+  </node>
 
-   <!-- spawn controller -->
-   <group if="$(arg use_ground_truth_for_control)">
-     <param name="controller/state_topic" value="" />
-     <param name="controller/imu_topic" value="" />
-   </group>
-   <group unless="$(arg use_ground_truth_for_control)">
-     <param name="controller/state_topic" value="state" />
-     <param name="controller/imu_topic" value="imu" />
-   </group>
-   <include file="$(find hector_quadrotor_controller)/launch/controller.launch" />
+  <!-- publish state and tf -->
+  <node name="ground_truth_to_tf" pkg="message_to_tf" type="message_to_tf" output="screen">
+    <param name="odometry_topic" value="ground_truth/state" />
+    <param name="frame_id" value="/world" />
+    <param name="tf_prefix" value="$(arg tf_prefix)" if="$(arg use_ground_truth_for_tf)" />
+    <param name="tf_prefix" value="$(arg tf_prefix)/ground_truth" unless="$(arg use_ground_truth_for_tf)" />
+  </node>
+  <group if="$(arg use_pose_estimation)">
+    <node name="pose_estimation" pkg="hector_quadrotor_pose_estimation" type="hector_quadrotor_pose_estimation" output="screen">
+      <rosparam file="$(find hector_quadrotor_pose_estimation)/params/simulation.yaml" />
+      <param name="nav_frame" value="$(arg tf_prefix)/nav" />
+      <param name="publish_world_nav_transform" value="true" />
+      <param name="tf_prefix" value="$(arg tf_prefix)" unless="$(arg use_ground_truth_for_tf)" />
+      <param name="tf_prefix" value="$(arg tf_prefix)/pose_estimation" if="$(arg use_ground_truth_for_tf)" />
+    </node>
+  </group>
 
-   <arg name="motors" default="robbe_2827-34_epp1045" />
-   <rosparam command="load" file="$(find hector_quadrotor_model)/param/quadrotor_aerodynamics.yaml" />
-   <rosparam command="load" file="$(find hector_quadrotor_model)/param/$(arg motors).yaml" />
+  <!-- spawn controller -->
+  <group if="$(arg use_ground_truth_for_control)">
+    <param name="controller/state_topic" value="" />
+    <param name="controller/imu_topic" value="" />
+  </group>
+  <group unless="$(arg use_ground_truth_for_control)">
+    <param name="controller/state_topic" value="state" />
+    <param name="controller/imu_topic" value="imu" />
+  </group>
+  <include file="$(arg controller_definition)" />
+
+  <arg name="motors" default="robbe_2827-34_epp1045" />
+  <rosparam command="load" file="$(find hector_quadrotor_model)/param/quadrotor_aerodynamics.yaml" />
+  <rosparam command="load" file="$(find hector_quadrotor_model)/param/$(arg motors).yaml" />
 
 </launch>

--- a/hector_quadrotor_gazebo/launch/spawn_quadrotor.launch
+++ b/hector_quadrotor_gazebo/launch/spawn_quadrotor.launch
@@ -14,8 +14,10 @@
    <arg name="use_pose_estimation" unless="$(arg use_ground_truth_for_control)" default="true"/>
 
    <!-- send the robot XML to param server -->
-   <param name="robot_description" command="$(find xacro)/xacro.py '$(arg model)'" />
+   <param name="robot_description" command="$(find xacro)/xacro.py '$(arg model)' base_link_frame:=$(arg tf_prefix)/base_link" />
    <param name="tf_prefix" type="string" value="$(arg tf_prefix)" />
+   <param name="base_link_frame" type="string" value="$(arg tf_prefix)/base_link"/>
+   <param name="world_frame" type="string" value="world"/>
 
    <!-- push robot_description to factory and spawn robot in gazebo -->
    <node name="spawn_robot" pkg="gazebo_ros" type="spawn_model"

--- a/hector_quadrotor_gazebo/urdf/quadrotor_aerodynamics.gazebo.xacro
+++ b/hector_quadrotor_gazebo/urdf/quadrotor_aerodynamics.gazebo.xacro
@@ -9,6 +9,7 @@
         <alwaysOn>true</alwaysOn>
         <updateRate>0.0</updateRate>
         <bodyName>base_link</bodyName>
+        <frameId>$(arg base_link_frame)</frameId>
       </plugin>
     </gazebo>
   </xacro:macro>

--- a/hector_quadrotor_gazebo/urdf/quadrotor_plugins.gazebo.xacro.in
+++ b/hector_quadrotor_gazebo/urdf/quadrotor_plugins.gazebo.xacro.in
@@ -1,6 +1,10 @@
 <?xml version="1.0"?>
 
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
+
+  <arg name="world_frame" default="world"/>
+  <arg name="base_link_frame" default="base_link"/>
+
   <xacro:include filename="$(find hector_quadrotor_gazebo)/urdf/quadrotor_sensors.gazebo.xacro" />
   <xacro:include filename="$(find hector_quadrotor_gazebo)/urdf/quadrotor_controller.gazebo.xacro" />
   <xacro:include filename="$(find hector_quadrotor_gazebo)/urdf/quadrotor_propulsion.gazebo.xacro" />

--- a/hector_quadrotor_gazebo/urdf/quadrotor_propulsion.gazebo.xacro
+++ b/hector_quadrotor_gazebo/urdf/quadrotor_propulsion.gazebo.xacro
@@ -9,6 +9,7 @@
         <alwaysOn>true</alwaysOn>
         <updateRate>0.0</updateRate>
         <bodyName>base_link</bodyName>
+        <frameId>$(arg base_link_frame)</frameId>
         <controlRate>100.0</controlRate>
         <!-- <controlTolerance>0.01</controlTolerance> -->
         <controlDelay>0.01</controlDelay>

--- a/hector_quadrotor_gazebo/urdf/quadrotor_sensors.gazebo.xacro
+++ b/hector_quadrotor_gazebo/urdf/quadrotor_sensors.gazebo.xacro
@@ -7,6 +7,7 @@
     <plugin name="quadrotor_imu_sim" filename="libhector_gazebo_ros_imu.so">
       <updateRate>100.0</updateRate>
       <bodyName>base_link</bodyName>
+      <frameId>$(arg base_link_frame)</frameId>
       <topicName>raw_imu</topicName>
       <rpyOffsets>0 0 0</rpyOffsets> <!-- deprecated -->
       <gaussianNoise>0</gaussianNoise>  <!-- deprecated -->
@@ -19,6 +20,7 @@
     <plugin name="quadrotor_baro_sim" filename="libhector_gazebo_ros_baro.so">
       <updateRate>10.0</updateRate>
       <bodyName>base_link</bodyName>
+      <frameId>$(arg base_link_frame)</frameId>
       <topicName>pressure_height</topicName>
       <altimeterTopicName>altimeter</altimeterTopicName>
       <offset>0</offset>
@@ -29,6 +31,7 @@
     <plugin name="quadrotor_magnetic_sim" filename="libhector_gazebo_ros_magnetic.so">
       <updateRate>10.0</updateRate>
       <bodyName>base_link</bodyName>
+      <frameId>$(arg base_link_frame)</frameId>
       <topicName>magnetic</topicName>
       <offset>0 0 0</offset>
       <drift>0.0 0.0 0.0</drift>
@@ -38,6 +41,7 @@
     <plugin name="quadrotor_gps_sim" filename="libhector_gazebo_ros_gps.so">
       <updateRate>4.0</updateRate>
       <bodyName>base_link</bodyName>
+      <frameId>$(arg base_link_frame)</frameId>
       <topicName>fix</topicName>
       <velocityTopicName>fix_velocity</velocityTopicName>
       <referenceLatitude>49.860246</referenceLatitude>
@@ -53,7 +57,7 @@
       <bodyName>base_link</bodyName>
       <topicName>ground_truth/state</topicName>
       <gaussianNoise>0.0</gaussianNoise>
-      <frameName>world</frameName>
+      <frameName>$(arg world_frame)</frameName>
     </plugin>
 
   </gazebo>

--- a/hector_quadrotor_gazebo_plugins/include/hector_quadrotor_gazebo_plugins/gazebo_quadrotor_aerodynamics.h
+++ b/hector_quadrotor_gazebo_plugins/include/hector_quadrotor_gazebo_plugins/gazebo_quadrotor_aerodynamics.h
@@ -77,6 +77,7 @@ private:
   double control_rate_;
   std::string wind_topic_;
   std::string wrench_topic_;
+  std::string frame_id_;
 
   common::Time last_time_;
 

--- a/hector_quadrotor_gazebo_plugins/include/hector_quadrotor_gazebo_plugins/gazebo_quadrotor_propulsion.h
+++ b/hector_quadrotor_gazebo_plugins/include/hector_quadrotor_gazebo_plugins/gazebo_quadrotor_propulsion.h
@@ -85,6 +85,7 @@ private:
   std::string wrench_topic_;
   std::string supply_topic_;
   std::string status_topic_;
+  std::string frame_id_;
   ros::Duration control_delay_;
   ros::Duration control_tolerance_;
 

--- a/hector_quadrotor_gazebo_plugins/src/gazebo_quadrotor_aerodynamics.cpp
+++ b/hector_quadrotor_gazebo_plugins/src/gazebo_quadrotor_aerodynamics.cpp
@@ -68,12 +68,14 @@ void GazeboQuadrotorAerodynamics::Load(physics::ModelPtr _model, sdf::ElementPtr
   param_namespace_ = "quadrotor_aerodynamics";
   wind_topic_ = "/wind";
   wrench_topic_ = "aerodynamics/wrench";
+  frame_id_ = link->GetName();
 
   // load parameters
   if (_sdf->HasElement("robotNamespace")) namespace_ = _sdf->GetElement("robotNamespace")->Get<std::string>();
   if (_sdf->HasElement("paramNamespace")) param_namespace_ = _sdf->GetElement("paramNamespace")->Get<std::string>();
   if (_sdf->HasElement("windTopicName"))  wind_topic_ = _sdf->GetElement("windTopicName")->Get<std::string>();
   if (_sdf->HasElement("wrenchTopic"))    wrench_topic_ = _sdf->GetElement("wrenchTopic")->Get<std::string>();
+  if (_sdf->HasElement("frameId"))    frame_id_= _sdf->GetElement("frameId")->Get<std::string>();
 
   // Make sure the ROS node for Gazebo has already been initialized
   if (!ros::isInitialized())
@@ -156,7 +158,7 @@ void GazeboQuadrotorAerodynamics::Update()
   if (wrench_publisher_) {
     geometry_msgs::WrenchStamped wrench_msg;
     wrench_msg.header.stamp = ros::Time(current_time.sec, current_time.nsec);
-    wrench_msg.header.frame_id = link->GetName();
+    wrench_msg.header.frame_id = frame_id_;
     wrench_msg.wrench = model_.getWrench();
     wrench_publisher_.publish(wrench_msg);
   }

--- a/hector_quadrotor_gazebo_plugins/src/gazebo_quadrotor_propulsion.cpp
+++ b/hector_quadrotor_gazebo_plugins/src/gazebo_quadrotor_propulsion.cpp
@@ -75,6 +75,7 @@ void GazeboQuadrotorPropulsion::Load(physics::ModelPtr _model, sdf::ElementPtr _
   status_topic_ = "motor_status";
   control_tolerance_ = ros::Duration();
   control_delay_ = ros::Duration();
+  frame_id_ = link->GetName();
 
   // load parameters
   if (_sdf->HasElement("robotNamespace"))   namespace_ = _sdf->GetElement("robotNamespace")->Get<std::string>();
@@ -85,6 +86,7 @@ void GazeboQuadrotorPropulsion::Load(physics::ModelPtr _model, sdf::ElementPtr _
   if (_sdf->HasElement("wrenchTopic"))      wrench_topic_ = _sdf->GetElement("wrenchTopic")->Get<std::string>();
   if (_sdf->HasElement("supplyTopic"))      supply_topic_ = _sdf->GetElement("supplyTopic")->Get<std::string>();
   if (_sdf->HasElement("statusTopic"))      status_topic_ = _sdf->GetElement("statusTopic")->Get<std::string>();
+  if (_sdf->HasElement("frameId"))          frame_id_= _sdf->GetElement("frameId")->Get<std::string>();
 
   if (_sdf->HasElement("voltageTopicName")) {
     gzwarn << "[quadrotor_propulsion] Plugin parameter 'voltageTopicName' is deprecated! Plese change your config to use "
@@ -229,7 +231,7 @@ void GazeboQuadrotorPropulsion::Update()
   if (wrench_publisher_) {
     geometry_msgs::WrenchStamped wrench_msg;
     wrench_msg.header.stamp = ros::Time(current_time.sec, current_time.nsec);
-    wrench_msg.header.frame_id = link->GetName();
+    wrench_msg.header.frame_id = frame_id_;
     wrench_msg.wrench = model_.getWrench();
     wrench_publisher_.publish(wrench_msg);
   }


### PR DESCRIPTION
required for multi-robot operation due to deprecation of tf_prefix (and lack of support for tf_prefix within hector_gazebo_plugins)

Prior to this fix, all hector_gazebo_plugins would publish data with frame 'base_link' instead of 'uav1/base_link' when spawning robots with a tf_prefix
